### PR TITLE
fix function binding example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ export function addTodoAndIncrement({text}) {
         ],
 
         // Pass actions in array
-        payload: [addTodo.bind(text), increment]
+        payload: [addTodo.bind(null, text), increment]
     };
 }
 


### PR DESCRIPTION
was working off the example and kept seeing `undefined` instead of the argument passed in for `text`. here is a fix to that!
