### PR TITLE
Do not apply combineActions middleware if payload is an empty array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 function isArrayOfFunctions(array) {
-    return Array.isArray(array) && array.every(item => item instanceof Function);
+    return Array.isArray(array) && array.length > 0 && array.every(item => item instanceof Function);
 }
 
 export default function reduxCombineActions() {


### PR DESCRIPTION
In case the action.payload is an empty array, it should not be considered as an array of functions.
